### PR TITLE
Update nkpDeploy.sh

### DIFF
--- a/nkpDeploy.sh
+++ b/nkpDeploy.sh
@@ -670,7 +670,6 @@ nkp create cluster nutanix \
   --ssh-public-key-file                       "${SSH_PUBLIC_KEY_FILE}" \
   --timeout                                          "60m0s" \
   --self-managed
-  --self-managed
 NKP_EXIT=$?
 
 if [[ $NKP_EXIT -eq 0 ]]; then


### PR DESCRIPTION
remove duplicate —self-managed from ‘nkp create cluster’ command. Process still completed successfully but threw a console error on completion.