### PR TITLE
NKP 2.18 readiness updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For NKP cluster creation:
 2. Create a virtual machine
 
     - Name: nkp-jump host
-    - vCPUs: 2
+    - vCPUs: 4
     - Memory: 8
     - Disk: Clone from Image (select the Rocky Linux you previously uploaded)
     - Disk Capacity: 128 (default is 20)

--- a/cloud-init
+++ b/cloud-init
@@ -25,7 +25,7 @@ bootcmd:
 
 runcmd:
   - mv /etc/yum.repos.d/nutanix_rocky9.repo /etc/yum.repos.d/nutanix_rocky9.repo.disabled
-  - dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  - dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
   - dnf -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin git tmux
   - systemctl --now enable docker
   - usermod -aG docker nutanix

--- a/nkpDeploy.sh
+++ b/nkpDeploy.sh
@@ -301,7 +301,6 @@ echo -e "${GREEN}--> Outbound connectivity verified.${NC}"
 # ============================================================
 # PREFLIGHT 3: FIND OR DOWNLOAD BUNDLE
 # ============================================================
-
 # Check for airgap bundle mistakenly placed in the directory
 if ls nkp-air-gapped-bundle_v*.tar.gz &>/dev/null; then
     echo -e "${RED}ERROR: Found an NKP Air-Gapped Bundle in the current directory.${NC}"
@@ -312,9 +311,17 @@ if ls nkp-air-gapped-bundle_v*.tar.gz &>/dev/null; then
     echo -e "  https://portal.nutanix.com/page/downloads?product=nkp"
     exit 1
 fi
-BUNDLE_FILE=$(ls -d nkp-bundle_v*/ 2>/dev/null | head -n1 | tr -d '/') && BUNDLE_FILE="${BUNDLE_FILE}.tar.gz" || \
-BUNDLE_FILE=$(ls nkp-bundle_v*.tar.gz 2>/dev/null | head -n1)
-if [ -z "$BUNDLE_FILE" ]; then
+
+# Try to find extracted directory first (populated on rerun)
+BUNDLE_DIR=$(ls -d nkp-bundle_v*/ 2>/dev/null | head -n1 | tr -d '/')
+if [[ -n "$BUNDLE_DIR" ]]; then
+    BUNDLE_FILE="${BUNDLE_DIR}.tar.gz"
+else
+    # Fall back to looking for tarball
+    BUNDLE_FILE=$(ls nkp-bundle_v*.tar.gz 2>/dev/null | head -n1)
+fi
+
+if [[ -z "$BUNDLE_FILE" ]]; then
     echo -e "${YELLOW}NKP Bundle not found in current directory.${NC}"
     echo -e "${YELLOW}Open browser to: ${NC}"
     echo -e "${YELLOW}https://portal.nutanix.com/page/downloads?product=nkp${NC}"


### PR DESCRIPTION
change docker-ce repo per rocky docs - https://docs.rockylinux.org/9/gemstones/containers/docker/. old url was failing during cloud-init process.

fix preflight 3 tarball handling 

update README.md for vcpu requirements for nkp 2.18